### PR TITLE
Issues from KIM project

### DIFF
--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -270,6 +270,11 @@ const Selector = ({
         );
     };
 
+    const optionClickHandler = (selectedOption: IOption | undefined): void => {
+        setFocusedObjIndex(-1);
+        onSelectHandler(selectedOption);
+    };
+
     const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
         const value = event.target.value;
         setSearchFilter(value);
@@ -397,7 +402,7 @@ const Selector = ({
             </div>
             {(showMenu || selectStyle === "list") && !isReadOnly && (
                 <OptionsMenu
-                    onSelect={onSelectHandler}
+                    onSelect={optionClickHandler}
                     currentFocus={options[focusedObjIndex]}
                     maxMenuHeight={maxMenuHeight}
                     noResultsText={noResultsText}

--- a/src/components/Selector.tsx
+++ b/src/components/Selector.tsx
@@ -273,6 +273,9 @@ const Selector = ({
     const optionClickHandler = (selectedOption: IOption | undefined): void => {
         setFocusedObjIndex(-1);
         onSelectHandler(selectedOption);
+        if (selectionType === "referenceSet") {
+            focusSearchInput(searchInput, 300);
+        }
     };
 
     const handleInputChange = (event: ChangeEvent<HTMLInputElement>): void => {
@@ -350,7 +353,10 @@ const Selector = ({
                             isClearable={isClearable}
                             isReadOnly={isReadOnly}
                             maxReferenceDisplay={maxReferenceDisplay}
-                            onRemove={clickObj => onSelectHandler(clickObj)}
+                            onRemove={clickObj => {
+                                onSelectHandler(clickObj);
+                                focusSearchInput(searchInput, 300);
+                            }}
                             referenceSetStyle={referenceSetStyle}
                             clearIcon={clearIcon}
                             onBadgeClick={onBadgeClick}


### PR DESCRIPTION
Reset focused index when clicking an option - prevents an option which was previously set as focused for keyboard navigation to automatically srcoll into view after selecting a different option by mouse. (When using Reference Set selection)

Focus search field after selecting or clearing an option - avoid extra click if user wants to search again